### PR TITLE
Use componentDidMount instead of componentWillMount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-queryable-container",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Know what your parents are up to",
   "keywords": [
     "react",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,28 +12,26 @@ export default class QueryableContainer extends Component {
 		this.queryContainerThrottled = _throttle(this.queryContainer, props.throttle, { "leading": false });
 	}
 
-	componentWillMount() {
-		if (global.window) {
-			global.window.addEventListener("resize", this.queryContainerThrottled);
-		}
+	componentDidMount() {
+		this._mounted = true;
+
+		window.addEventListener("resize", this.queryContainerThrottled);
+
 		if (this.props.poll) {
 			this.setState({
 				timer: setInterval(this.queryContainerThrottled, this.props.throttle)
 			});
 		}
-	}
 
-	componentDidMount() {
-		this._mounted = true;
 		this.queryContainer();
 		setTimeout(this.queryContainer, 0);
 	}
 
 	componentWillUnmount() {
 		this._mounted = false;
-		if (global.window) {
-			global.window.removeEventListener("resize", this.queryContainerThrottled);
-		}
+
+		window.removeEventListener("resize", this.queryContainerThrottled);
+
 		if (this.state.timer) {
 			clearInterval(this.state.timer);
 		}


### PR DESCRIPTION
`componentDidMount` is only called when the component actually mounts. This means it will only be called when rendering on the client since the server will never actually mount any components anywhere when rendering.

`componentWillMount`, on the other hand, will be called before the component mounts when rendering on the client and also be called on the server where window will not be defined.

`componentDidMount` is the more appropriate place for the code which uses the DOM and sets event handlers on `window`.